### PR TITLE
Bundle the jbang jars inside docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,18 @@ RUN wget https://github.com/jbangdev/jbang/releases/download/v0.91.0/jbang-0.91.
     unzip -q jbang-*.zip && \
     mv jbang-0.91.0 jbang  && \
     rm jbang*.zip
+
 ENV PATH="/opt/jbang/bin:${PATH}"
+
+COPY ./bin/RegenieFilter.java ./
+RUN jbang export portable -O=RegenieFilter.jar RegenieFilter.java
+
+COPY ./bin/RegenieLogParser.java ./
+RUN jbang export portable -O=RegenieLogParser.jar RegenieLogParser.java
+
+COPY ./bin/RegenieValidateInput.java ./
+RUN jbang export portable -O=RegenieValidateInput.jar RegenieValidateInput.java
+
 
 # Install regenie (not as conda package available)
 WORKDIR "/opt"

--- a/modules/local/validate_phenotypes.nf
+++ b/modules/local/validate_phenotypes.nf
@@ -11,6 +11,6 @@ process VALIDATE_PHENOTYPES {
     path "${phenotypes_file.baseName}.validated.log", emit: phenotypes_file_validated_log
 
   """
-  java -jar ${regenie_validate_input_jar}  --input ${phenotypes_file} --output  ${phenotypes_file.baseName}.validated.txt --type phenotype
+  java -jar /opt/RegenieValidateInput.jar --input ${phenotypes_file} --output  ${phenotypes_file.baseName}.validated.txt --type phenotype
   """
   }

--- a/modules/local/validate_phenotypes.nf
+++ b/modules/local/validate_phenotypes.nf
@@ -5,7 +5,6 @@ process VALIDATE_PHENOTYPES {
 
   input:
     path phenotypes_file
-    path regenie_validate_input_jar
 
   output:
     path "${phenotypes_file.baseName}.validated.txt", emit: phenotypes_file_validated

--- a/workflows/nf_gwas.nf
+++ b/workflows/nf_gwas.nf
@@ -84,17 +84,16 @@ include { REPORT                      } from '../modules/local/report'  addParam
 
 workflow NF_GWAS {
 
-    CACHE_JBANG_SCRIPTS (
-        regenie_log_parser_java,
-        regenie_filter_java,
-        regenie_validate_input_java
-    )
+    // CACHE_JBANG_SCRIPTS (
+    //     regenie_log_parser_java,
+    //     regenie_filter_java,
+    //     regenie_validate_input_java
+    // )
 
     VALIDATE_PHENOTYPES (
-        phenotypes_file,
-        CACHE_JBANG_SCRIPTS.out.regenie_validate_input_jar
+        phenotypes_file
     )
-
+/*
     if(covariates_file.exists()) {
         VALIDATE_COVARIATS (
           covariates_file,
@@ -226,6 +225,7 @@ REGENIE_STEP2.out.regenie_step2_out
         regenie_step1_parsed_logs_ch.collect(),
         REGENIE_LOG_PARSER_STEP2.out.regenie_step2_parsed_logs
     )
+*/
 }
 
 workflow.onComplete {


### PR DESCRIPTION
This PR explores the colocation of jbang-compiled jars into the docker container itself.

> NOTE: In this POC, I've hardcoded the path of the JAR in the process, to avoid having to rebuild/push the docker container again which needs to be tweaked accordingly.

As of https://github.com/abhi18av/nf-gwas/pull/2/commits/97d075d63fe41569016560713f179a0487aad4ff , this approach is working.

- On `local` executor

```
N E X T F L O W  ~  version 22.04.5
Launching `main.nf` [backstabbing_liskov] DSL2 - revision: 6e13e51147
executor >  local (1)
[29/57e2f7] process > NF_GWAS:VALIDATE_PHENOTYPES [100%] 1 of 1 ✔
Pipeline completed at: 2022-08-19T10:35:17.167361542+02:00
Execution status: OK


```

- On `azure` executor 

```
N E X T F L O W  ~  version 22.08.2-edge
Launching `./main.nf` [cranky_noyce] DSL2 - revision: 6e13e51147
Uploading local `bin` scripts folder to az://batch-jobs/nf-gwas-workdir/tmp/2c/8b5df3e5d7a4229ba4e2a2d27a4beb/bin
executor >  azurebatch (1)
[94/c78916] process > NF_GWAS:VALIDATE_PHENOTYPES [100%] 1 of 1 ✔
Pipeline completed at: 2022-08-19T10:44:09.673403+02:00
Execution status: OK
Completed at: 19-Aug-2022 10:44:10
Duration    : 3m 20s
CPU hours   : (a few seconds)
Succeeded   : 1


```